### PR TITLE
Disable buildx provenance (unknown/unknown arch)

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -29,13 +29,16 @@ jobs:
         images:
           - dockerfile: base/al2023/Dockerfile
             directory: base/al2023
-            image: ghcr.io/${{ github.repository_owner }}/al2023:latest
+            image: ${{ github.repository_owner }}/al2023:latest
+            description: "Amazon Linux 2023"
           - dockerfile: base/alpine/Dockerfile
             directory: base/alpine
-            image: ghcr.io/${{ github.repository_owner }}/alpine:latest
+            image: ${{ github.repository_owner }}/alpine:latest
+            description: "Alpine Linux"
           - dockerfile: base/debian/Dockerfile
             directory: base/debian
-            image: ghcr.io/${{ github.repository_owner }}/debian:latest
+            image: ${{ github.repository_owner }}/debian:latest
+            description: "Debian Linux (Slim)"
     outputs:
       digests: ${{ steps.push-image.outputs.digest }}
     steps:
@@ -69,3 +72,4 @@ jobs:
           labels: |-
             org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.source=https://github.com/${{ github.repository}}
+            org.opencontainers.image.description=${{ matrix.images.description }}

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Set up QEMU."
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: "Set up Docker Buildx."
         uses: docker/setup-buildx-action@v3
         with:
@@ -63,6 +63,7 @@ jobs:
           context:
           file: ${{ matrix.images.dockerfile }}
           push: true
+          provenance: false
           tags: ${{ matrix.images.image }}
           platforms: ${{ matrix.platforms }}
           labels: |-

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -26,6 +26,7 @@ jobs:
         platforms:
           - linux/amd64
           - linux/arm64
+          - linux/arm/v7
         images:
           - dockerfile: base/al2023/Dockerfile
             directory: base/al2023


### PR DESCRIPTION
Docker Buildx's provenance feature adds metadata that is not compatible with GHCR. Disabling it for now.