### PR TITLE
Additional platforms for build and base

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -26,6 +26,8 @@ jobs:
         platforms:
           - linux/amd64
           - linux/arm64
+          - linux/arm/v7
+          - linux/arm/v8
         images:
           - dockerfile: base/al2023/Dockerfile
             directory: base/al2023

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -23,11 +23,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        all_platforms:
-          - linux/amd64
-          - linux/arm64
-          - linux/arm/v7
-          - linux/arm/v8
         images:
           - dockerfile: base/al2023/Dockerfile
             directory: base/al2023
@@ -55,7 +50,7 @@ jobs:
               - linux/arm/v7
               - linux/arm/v8
     outputs:
-      digests: ${{ steps.push-image.outputs.digest }}
+      digests: ${{ steps.build-push-image.outputs.digest }}
     steps:
       - name: "Checkout repository."
         uses: actions/checkout@v4
@@ -67,7 +62,7 @@ jobs:
       - name: "Set up Docker Buildx."
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{ join(matrix.images.all_platforms, ',') }}
+          platforms: ${{ join(matrix.images.supported_platforms, ',') }}
       - name: "Login: ghcr.io"
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -67,23 +67,24 @@ jobs:
       - name: "Set up Docker Buildx."
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{ matrix.all_platforms }}
+          platforms: ${{ join(matrix.images.all_platforms, ',') }}
       - name: "Login: ghcr.io"
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Push image."
-        id: push-image
+      - name: "Build and push image."
+        id: build-push-image
         uses: docker/build-push-action@v5
+        if:
         with:
           context:
           file: ${{ matrix.images.dockerfile }}
           push: true
           provenance: false
           tags: ${{ matrix.images.image }}
-          platforms: ${{ matrix.images.supported_platforms }}
+          platforms: ${{ join(matrix.images.supported_platforms, ',') }}
           labels: |-
             org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.source=https://github.com/${{ github.repository}}

--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platforms:
+        all_platforms:
           - linux/amd64
           - linux/arm64
           - linux/arm/v7
@@ -33,14 +33,27 @@ jobs:
             directory: base/al2023
             image: ghcr.io/${{ github.repository_owner }}/al2023:latest
             description: "Amazon Linux 2023"
+            supported_platforms:
+              - linux/amd64
+              - linux/arm64
           - dockerfile: base/alpine/Dockerfile
             directory: base/alpine
             image: ghcr.io/${{ github.repository_owner }}/alpine:latest
             description: "Alpine Linux"
+            supported_platforms:
+              - linux/amd64
+              - linux/arm64
+              - linux/arm/v7
+              - linux/arm/v8
           - dockerfile: base/debian/Dockerfile
             directory: base/debian
             image: ghcr.io/${{ github.repository_owner }}/debian:latest
             description: "Debian Linux (Slim)"
+            supported_platforms:
+              - linux/amd64
+              - linux/arm64
+              - linux/arm/v7
+              - linux/arm/v8
     outputs:
       digests: ${{ steps.push-image.outputs.digest }}
     steps:
@@ -54,7 +67,7 @@ jobs:
       - name: "Set up Docker Buildx."
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: ${{ matrix.platforms }}
+          platforms: ${{ matrix.all_platforms }}
       - name: "Login: ghcr.io"
         uses: docker/login-action@v3
         with:
@@ -70,7 +83,7 @@ jobs:
           push: true
           provenance: false
           tags: ${{ matrix.images.image }}
-          platforms: ${{ matrix.platforms }}
+          platforms: ${{ matrix.images.supported_platforms }}
           labels: |-
             org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.source=https://github.com/${{ github.repository}}

--- a/.github/workflows/build-tool-images.yml
+++ b/.github/workflows/build-tool-images.yml
@@ -31,6 +31,8 @@ jobs:
         platforms:
           - linux/amd64
           - linux/arm64
+          - linux/arm/v7
+          - linux/arm/v8
         images:
           - dockerfile: tools/opentofu/Dockerfile
             directory: tools/opentofu/Dockerfile
@@ -67,7 +69,7 @@ jobs:
           tags: ${{ matrix.images.image }}
           platforms: ${{ matrix.platforms }}
           build-args: |
-            --build-arg BUILD_ARCH=$(tr -d 'linux/' <<< "${{ matrix.platforms }}")
+            --build-arg BUILD_ARCH=$(echo ${{ matrix.platforms }} | cut -d'/' -f2)
           labels: |-
             org.opencontainers.image.vendor=${{ github.repository_owner }}
             org.opencontainers.image.source=https://github.com/${{ github.repository}}


### PR DESCRIPTION
Add additional platforms for image builds:
  - `linux/arm/v7`
  - `linux/arm/v8`

Amazon Linux 2023 does not support them, so its excluded these platforms from the image build.