### PR TITLE
OpenTofu: 1.6.0 is GA

### DIFF
--- a/tools/opentofu/Dockerfile
+++ b/tools/opentofu/Dockerfile
@@ -9,7 +9,9 @@ LABEL org.opencontainers.image.source="https://github.com/opentofu/opentofu/"
 ARG WORKDIR=/tmp/opentofu
 ARG BUILD_ARCH=arm64
 ARG APP=tofu
-ARG VERSION='1.6.0-rc1'
+ARG VERSION='1.6.0'
+
+ENV USER=outis
 
 WORKDIR ${WORKDIR}
 
@@ -19,9 +21,12 @@ RUN apk add --no-cache \
 RUN curl -fsSL \
     -o "${WORKDIR}/${APP}.apk" \
     "https://github.com/opentofu/opentofu/releases/download/v${VERSION}/${APP}_${VERSION}_${BUILD_ARCH}.apk" \
-    && apk add --no-cache --allow-untrusted \
-        "${WORKDIR}/${APP}.apk" \
-        && rm -rf "${WORKDIR}/${APP}.apk"
+    && \
+    apk add --no-cache --allow-untrusted \
+    "${WORKDIR}/${APP}.apk" \
+    && rm -rf "${WORKDIR}/${APP}.apk"
+
+USER ${USER}
 
 ENTRYPOINT [ "tofu" ]
 CMD [ "--help" ]


### PR DESCRIPTION
- Update OpenTofu to v1.6.0.
- Fix indentation in Dockerfile.
- User should be `outis`.