### PR TITLE
Add more platforms for kubectl build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -140,6 +140,9 @@ jobs:
             supported_platforms:
               - linux/amd64
               - linux/arm64
+              - linux/arm/v7
+              - linux/arm/v8
+              - linux/arm64/v8
     outputs:
       digests: ${{ steps.push-image.outputs.digest }}
     steps:


### PR DESCRIPTION
Add additional platforms to `kubectl` build (ARM variants).