### PR TITLE
renovate(bot): Add SHA digests to Dockerfiles.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   ],
   "assigneesFromCodeOwners": true,
   "dependencyDashboardTitle": "renovate(bot): Dependency Dashboard",
+  "pinDigests": true,
   "semanticCommits": "enabled",
   "timezone": "Etc/UTC"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
A safe way of continuing to use the `latest` tag, maybe?

Need to ensure that builds aren't triggered with each commit to trunk to avoid ending up in PR hell.